### PR TITLE
FIX 重すぎ/軽すぎの表示が残るバグを修正

### DIFF
--- a/src/components/UserChange.vue
+++ b/src/components/UserChange.vue
@@ -202,6 +202,7 @@
                 }
                 else {
                     SignWeight = true
+                    this.ChangeValidation.ChangeWeightResult = ""
                 }
 
                 // 身長の入力フォームのバリデーション
@@ -231,6 +232,7 @@
                 }
                 else {
                     SignHeight = true
+                    this.ChangeValidation.ChangeHeightResult = ""
                 }
 
                 // 身体レベルの入力フォームのバリデーション

--- a/src/components/UserSignUp.vue
+++ b/src/components/UserSignUp.vue
@@ -391,7 +391,6 @@
                 else {
                     SignWeight = true
                     this.SignupValidation.SignupWeightResult = ""
-
                 }
 
                 // 身長の入力フォームのバリデーション
@@ -422,7 +421,6 @@
                 else {
                     SignHeight = true
                     this.SignupValidation.SignupHeightResult = ""
-
                 }
 
                 // 氏名の入力フォームのバリデーション

--- a/src/components/UserSignUp.vue
+++ b/src/components/UserSignUp.vue
@@ -390,6 +390,8 @@
                 }
                 else {
                     SignWeight = true
+                    this.SignupValidation.SignupWeightResult = ""
+
                 }
 
                 // 身長の入力フォームのバリデーション
@@ -419,6 +421,8 @@
                 }
                 else {
                     SignHeight = true
+                    this.SignupValidation.SignupHeightResult = ""
+
                 }
 
                 // 氏名の入力フォームのバリデーション


### PR DESCRIPTION
・重すぎ/軽すぎの場合は正常値を入力してもその表示が残り正常値を入力したことがわかりにくいため